### PR TITLE
Extract Matomo tracking to tdp_matomo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ordino_product",
   "description": "",
   "homepage": "https://phovea.caleydo.org",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "author": {
     "name": "Samuel Gratzl",
     "email": "sam@sgratzl.com"

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -62,11 +62,7 @@
     "label": "ordino_server",
     "repo": "phovea/phovea_server",
     "branch": "v2.2.0",
-    "additional": [{
-        "name": "ordino_public",
-        "repo": "Caleydo/ordino_public",
-        "branch": "v5.1.0"
-      },
+    "additional": [
       {
         "name": "phovea_security_flask",
         "repo": "phovea/phovea_security_flask",

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -54,6 +54,11 @@
         "name": "phovea_security_store_generated",
         "repo": "datavisyn/phovea_security_store_generated",
         "branch": "v5.0.0"
+      },
+      {
+        "name": "tdp_matomo",
+        "repo": "datavisyn/tdp_matomo",
+        "branch": "v1.0.0"
       }
     ]
   },
@@ -104,6 +109,11 @@
         "name": "phovea_security_store_generated",
         "repo": "datavisyn/phovea_security_store_generated",
         "branch": "v5.0.0"
+      },
+      {
+        "name": "tdp_matomo",
+        "repo": "datavisyn/tdp_matomo",
+        "branch": "v1.0.0"
       }
     ]
   }


### PR DESCRIPTION
* Extract Matomo tracking to [tdp_matomo](https://github.com/datavisyn/tdp_matomo) (#25)
* Tracking is now enabled directly in Ordino (https://github.com/Caleydo/ordino/pull/202)
* Removed Matomo extension by reverting to release v5.0.2 (#26)