### PR TITLE
Generate phoveaMetaData.json from workspace/product package.json…

### DIFF
--- a/build.js
+++ b/build.js
@@ -360,7 +360,7 @@ function postBuild(p, dir, buildInSubDir) {
     .then(mergeCompose);
 }
 
-function buildWebApp(p, dir) {
+function buildWebApp(p, dir, yoWorkspaceOptions) {
   console.log(dir, chalk.blue('building web application:'), p.label);
   const name = p.name;
   const hasAdditional = p.additional.length > 0;
@@ -368,7 +368,7 @@ function buildWebApp(p, dir) {
   // let act = Promise.resolve(null);
   if (hasAdditional) {
     act = act
-      .then(() => yo('workspace', {noAdditionals: true, defaultApp: 'targid_boehringer'}, dir))
+      .then(() => yo('workspace', yoWorkspaceOptions, dir))
       .then(() => npm(dir, 'install'));
     // test all modules
     if (hasAdditional && !argv.skipTests) {
@@ -386,13 +386,13 @@ function buildWebApp(p, dir) {
     .then(postBuild.bind(null, p, dir, true));
 }
 
-function buildServerApp(p, dir) {
+function buildServerApp(p, dir, yoWorkspaceOptions) {
   console.log(dir, chalk.blue('building service package:'), p.label);
   const name = p.name;
 
   let act = preBuild(p, dir);
   act = act
-    .then(() => yo('workspace', {noAdditionals: true, defaultApp: 'targid_boehringer'}, dir));
+    .then(() => yo('workspace', yoWorkspaceOptions, dir));
 
   if (!argv.skipTests) {
     act = act
@@ -423,15 +423,23 @@ function buildServerApp(p, dir) {
 }
 
 function buildImpl(d, dir) {
+  const yoWorkspaceOptions = {
+    noAdditionals: true,
+    defaultApp: 'ordino_public',
+    wsName: pkg.name,
+    wsDescription: pkg.description,
+    wsVersion: pkg.version
+  };
+
   switch (d.type) {
     case 'static':
     case 'web':
-      return buildWebApp(d, dir);
+      return buildWebApp(d, dir, yoWorkspaceOptions);
     case 'api':
       d.name = d.name || 'phovea_server';
-      return buildServerApp(d, dir);
+      return buildServerApp(d, dir, yoWorkspaceOptions);
     case 'service':
-      return buildServerApp(d, dir);
+      return buildServerApp(d, dir, yoWorkspaceOptions);
     default:
       console.error(chalk.red('unknown product type: ' + d.type));
       return Promise.resolve(null);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ordino_product",
   "description": "",
   "homepage": "https://phovea.caleydo.org",
-  "version": "6.0.0-SNAPSHOT",
+  "version": "5.0.1-SNAPSHOT",
   "author": {
     "name": "Samuel Gratzl",
     "email": "samuel_gratzl@gmx.at",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bluebird": "3.4.6",
     "chalk": "1.1.3",
     "fs-extra": "^1.0.0",
-    "generator-phovea": "github:phovea/generator-phovea",
+    "generator-phovea": "github:phovea/generator-phovea#88ad91dd288d25e0b0b34101d46656bc3c623fd3",
     "lodash": "^4.17.14",
     "mkdirp": "0.5.1",
     "yamljs": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ordino_product",
   "description": "",
   "homepage": "https://phovea.caleydo.org",
-  "version": "5.0.1-SNAPSHOT",
+  "version": "6.0.0-SNAPSHOT",
   "author": {
     "name": "Samuel Gratzl",
     "email": "samuel_gratzl@gmx.at",

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -2,7 +2,7 @@
   "type": "web",
   "label": "ordino",
   "repo": "Caleydo/ordino_public",
-  "branch": "thinkh/use-workspace-for-phoveaMetaData.json",
+  "branch": "develop",
   "additional": [
     {
       "name": "phovea_core",

--- a/phovea_product.json
+++ b/phovea_product.json
@@ -2,7 +2,7 @@
   "type": "web",
   "label": "ordino",
   "repo": "Caleydo/ordino_public",
-  "branch": "develop",
+  "branch": "thinkh/use-workspace-for-phoveaMetaData.json",
   "additional": [
     {
       "name": "phovea_core",


### PR DESCRIPTION
Related issue https://github.com/phovea/generator-phovea/issues/189

Requires PR https://github.com/phovea/generator-phovea/pull/190 and https://github.com/Caleydo/ordino_public/pull/30.

### Summary

* Pass information from the product _package.json_ to the `yo phovea:workspace` command in the _build.js_ (requires https://github.com/phovea/generator-phovea/pull/190)
* Generate a workspace _package.json_ with custom information
* The workspace _package.json_ is used to generate the _phoveaMetaData.json_ (requires https://github.com/Caleydo/ordino_public/pull/30)

The correct version number can be seen when building the product:

![grafik](https://user-images.githubusercontent.com/5851088/66050107-db2d1f80-e52c-11e9-8be1-f25b46af4342.png)

The git commit hash of the generator-phovea in the _package.json_ must be reset after the new release of the generator.

https://github.com/Caleydo/ordino_product/blob/e86a66dc81b5b70643841968ced186937a982756/package.json#L28
