### PR TITLE
Activate nightly CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,16 +91,16 @@ jobs:
 
 workflows:
   version: 2
-#  build-nightly:
-#    triggers:
-#      - schedule: # nightly build during weekday
-#          cron: "15 1 * * 1-5"
-#          filters:
-#            branches:
-#              only:
-#                - develop
-#    jobs:
-#      - build
+  build-nightly:
+    triggers:
+      - schedule: # nightly build during weekday
+          cron: "15 1 * * 1-5"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - build
   build-branch:
     jobs:
       - build:


### PR DESCRIPTION
Use the [CircleCI scheduled workflow](https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow), instead of our custom AWS trigger for nightly builds.