### PR TITLE
Add `injectionVersion` flag in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
               ;;
             esac
             echo "using tag: --${awsTag}--"
-            node build.js --skipSaveImage --skipTests --noDefaultTags --pushExtra=${awsTag} --pushTo=922145058410.dkr.ecr.eu-central-1.amazonaws.com/caleydo
+            node build.js --injectVersion --skipSaveImage --skipTests --noDefaultTags --pushExtra=${awsTag} --pushTo=922145058410.dkr.ecr.eu-central-1.amazonaws.com/caleydo
       - store_artifacts:
           path: build
           destination: build


### PR DESCRIPTION
Closes #22

### How to test

1. Open the last CircleCI build
2. Check the logs of the _build and deploy_ step and compare with version number in the product package.json
3. Download the tar.gz file from the CircleCI artifacts and check the phoveaMetaData.json