### PR TITLE
Adds separate dependencies and separates multicontainer deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 *.css
 *.log
 /tmp*/
+/helm-charts/charts/

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ordino
-description: A Helm chart for Kubernetes
+description: A Helm chart for Ordino
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,3 +21,18 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 6.0.1
+
+# Dependencies
+dependencies:
+  - name: redis 
+    version: 10.5.6
+    repository: "https://kubernetes-charts.storage.googleapis.com/"
+    condition: redis.enabled
+  - name: mongodb
+    version: 8.2.1
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: mongodb.enabled
+  - name: postgresql
+    version: "8.6.4"
+    repository: "https://kubernetes-charts.storage.googleapis.com/"
+    condition: postgresql.enabled

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: mongodb.enabled
   - name: postgresql
-    version: "8.6.4"
+    version: 8.6.4
     repository: "https://kubernetes-charts.storage.googleapis.com/"
     condition: postgresql.enabled

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -63,6 +63,77 @@ sh utils/k8s-dashboard/uninstall.sh
 
 ### Ordino
 
+## Chart Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | mongodb | 8.2.1 |
+| https://kubernetes-charts.storage.googleapis.com/ | postgresql | 8.6.4 |
+| https://kubernetes-charts.storage.googleapis.com/ | redis | 10.5.6 |
+
+
+## Chart Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| MongoDBName | string | `"ordinoDB"` |  |
+| MongoDBPass | string | `"ordinoAdmin"` |  |
+| MongoDBUser | string | `"ordinoAdmin"` |  |
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"nginx"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| mongodb.auth.database | string | `"ordinoDB"` | MongoDB custom database |
+| mongodb.auth.enabled | bool | `false` | Flag to control whether to enable authentication |
+| mongodb.auth.password | string | `"ordinoAdmin"` | MongoDB custom user password |
+| mongodb.auth.username | string | `"ordinoAdmin"` | MongoDB custom user (mandatory if auth.database is set) |
+| mongodb.enabled | bool | `true` | Flag to control whether to deploy MongoDB |
+| mongodb.fullnameOverride | string | `"mongodb"` | Name override for the MongoDB deployment |
+| mongodb.persistence.enabled | bool | `true` |  |
+| mongodb.persistence.size | string | `"1Gi"` | Size of the MongoDB pvc |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| ordino.mongodb.database | string | `"ordinoDB"` | MongoDB custom database |
+| ordino.mongodb.host | string | `"mongodb"` | MongoDB host |
+| ordino.mongodb.password | string | `"ordinoAdmin"` | MongoDB custom user password |
+| ordino.mongodb.port | string | `"27017"` | MongoDB port |
+| ordino.mongodb.username | string | `"ordinoAdmin"` | MongoDB custom user (mandatory if auth.database is set) |
+| ordino.redis.host | string | `"redis-headless"` | Name of the Redis host to be used |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| postgresql.enabled | bool | `true` | Flag to control whether to deploy PostgreSQL |
+| postgresql.existingSecret | string | `"ordinopostgrescredentials"` | Name of existing secret that holds passwords for PostgreSQL |
+| postgresql.fullnameOverride | string | `"postgresql"` | Name override for the PostgreSQL deployment |
+| postgresql.persistence.size | string | `"1Gi"` | Size of the PostgreSQL pvc |
+| postgresql.pgPass | string | `"pass"` | Password for the master PostgreSQL user. Feeds into the `ordinopostgrescredentials` secret that is provided to the PostgreSQL chart |
+| redis.cluster.enabled | bool | `false` | Cluster mode for Redis |
+| redis.enabled | bool | `true` | Flag to control whether to deploy Redis |
+| redis.fullnameOverride | string | `"redis"` | Name override for the redis deployment |
+| redis.master.persistence.enabled | bool | `false` | Enable redis volume claim |
+| redis.master.persistence.size | string | `"1Gi"` | Size of the volume claim |
+| redis.usePassword | bool | `false` | Use password for accessing redis |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+
+
 #### Install
 
 ```bash

--- a/helm-charts/templates/configuration.yaml
+++ b/helm-charts/templates/configuration.yaml
@@ -12,17 +12,21 @@ data:
         "port": 9000,
       },
       "tdp_core": {
-        "host": "localhost"
+        "host": "{{ .Values.ordino.mongodb.host }}",
+        "port": {{ .Values.ordino.mongodb.port }},
+        "database": "targid"
       },
       "phovea_data_mongo": {
-        "host": "localhost"
+        "host": "@{{ .Values.ordino.mongodb.host }}",
+        "port": {{ .Values.ordino.mongodb.port }},
+        "db": "graph"
       },
       "phovea_data_redis": {
         "assigner": {
-          "hostname": "localhost"
+          "hostname": "{{ .Values.ordino.redis.host }}"
         },
         "mapping": {
-          "hostname": "localhost"
+          "hostname": "{{ .Values.ordino.redis.host }}"
         }
       },
       "tdp_publicdb": {

--- a/helm-charts/templates/configuration.yaml
+++ b/helm-charts/templates/configuration.yaml
@@ -8,16 +8,16 @@ data:
   config.json: |-
     {
       "phovea_server": {
-        "debug": false,
-        "port": 9000,
+        "debug": {{ .Values.ordino.server.debug }},
+        "port": {{ .Values.ordino.server.port }},
       },
       "tdp_core": {
-        "host": "{{ .Values.ordino.mongodb.host }}",
+        "host": "mongodb://{{ .Values.ordino.mongodb.username }}:{{ .Values.ordino.mongodb.password }}@{{ .Values.ordino.mongodb.host }}/targid{{ .Values.ordino.mongodb.extraArgs }}",
         "port": {{ .Values.ordino.mongodb.port }},
         "database": "targid"
       },
       "phovea_data_mongo": {
-        "host": "@{{ .Values.ordino.mongodb.host }}",
+        "host": "mongodb://{{ .Values.ordino.mongodb.username }}:{{ .Values.ordino.mongodb.password }}@{{ .Values.ordino.mongodb.host }}/graph{{ .Values.ordino.mongodb.extraArgs }}",
         "port": {{ .Values.ordino.mongodb.port }},
         "db": "graph"
       },

--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -30,13 +30,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: web
-          image: caleydo/ordino:starter
+          image: {{ .Values.ordino.web.image }}:{{ .Values.ordino.web.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: PHOVEA_API_SERVER
-              value: ordino-server
+              value: {{ include "ordino.fullname" . }}-server
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.ordino.web.port }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/templates/deploymentordinoserver.yaml
+++ b/helm-charts/templates/deploymentordinoserver.yaml
@@ -30,10 +30,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: server
-          image: caleydo/ordino_server:starter
+          image: {{ .Values.ordino.server.image }}:{{ .Values.ordino.server.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: server
-              containerPort: 9000
+              containerPort: {{ .Values.ordino.server.port }}
           volumeMounts:
             - name: {{ include "ordino.fullname" . }}-configuration-volume
               mountPath: /phovea.config

--- a/helm-charts/templates/deploymentordinoserver.yaml
+++ b/helm-charts/templates/deploymentordinoserver.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "ordino.fullname" . }}-web
+  name: {{ include "ordino.fullname" . }}-server
   labels:
     {{- include "ordino.labels" . | nindent 4 }}
 spec:
@@ -19,7 +19,7 @@ spec:
     {{- end }}
       labels:
         {{- include "ordino.selectorLabels" . | nindent 8 }}
-        ordino-part: web
+        ordino-part: server
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -29,14 +29,17 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: web
-          image: caleydo/ordino:starter
-          env:
-            - name: PHOVEA_API_SERVER
-              value: ordino-server
+        - name: server
+          image: caleydo/ordino_server:starter
           ports:
-            - name: http
-              containerPort: 80
+            - name: server
+              containerPort: 9000
+          volumeMounts:
+            - name: {{ include "ordino.fullname" . }}-configuration-volume
+              mountPath: /phovea.config
+          env:
+            - name: PHOVEA_CONFIG_PATH
+              value: /phovea.config/config.json
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/templates/postgrescredentials.yaml
+++ b/helm-charts/templates/postgrescredentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ordinopostgrescredentials
+type: Opaque
+stringData:
+  postgresql-password: {{ .Values.postgresql.pgPass }}
+  postgresql-postgres-password: {{ .Values.postgresql.pgPass }}

--- a/helm-charts/templates/service.yaml
+++ b/helm-charts/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.ordino.web.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/helm-charts/templates/serviceordinoserver.yaml
+++ b/helm-charts/templates/serviceordinoserver.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ordino.fullname" . }}-web
+  name: {{ include "ordino.fullname" . }}-server
   labels:
     {{- include "ordino.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 9000
       protocol: TCP
       name: http
   selector:
     {{- include "ordino.selectorLabels" . | nindent 4 }}
-    ordino-part: web
+    ordino-part: server

--- a/helm-charts/templates/serviceordinoserver.yaml
+++ b/helm-charts/templates/serviceordinoserver.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 9000
+      targetPort: {{ .Values.ordino.server.port }}
       protocol: TCP
       name: http
   selector:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -14,6 +14,27 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+#Variables
+MongoDBName: &MongoDBName "ordinoDB"
+MongoDBUser: &MongoDBUser "ordinoAdmin"
+MongoDBPass: &MongoDBPass "ordinoAdmin"
+
+ordino:
+  redis:
+    # ordino.redis.host -- Name of the Redis host to be used
+    host: "redis-headless"
+  mongodb:
+    # ordino.mongodb.username -- MongoDB custom user (mandatory if auth.database is set)
+    username: *MongoDBUser
+    # ordino.mongodb.password -- MongoDB custom user password
+    password: *MongoDBPass
+    # ordino.mongodb.database -- MongoDB custom database
+    database: *MongoDBName
+    # ordino.mongodb.host -- MongoDB host
+    host: "mongodb"
+    # ordino.mongodb.port -- MongoDB port
+    port: "27017"
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -77,3 +98,54 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+redis:
+  # Please see all available overrides at https://github.com/helm/charts/tree/master/stable/redis
+  # redis.enabled -- Flag to control whether to deploy Redis
+  enabled: true
+  # redis.fullnameOverride -- Name override for the redis deployment
+  fullnameOverride: "redis"
+  cluster:
+    # redis.cluster.enabled -- Cluster mode for Redis
+    enabled: false
+  master:
+    persistence:
+      # redis.master.persistence.enabled -- Enable redis volume claim
+      enabled: false
+      # redis.master.persistence.size -- Size of the volume claim
+      size: 1Gi
+  # redis.usePassword -- Use password for accessing redis
+  usePassword: false
+
+postgresql:
+  # postgresql.enabled -- Flag to control whether to deploy PostgreSQL
+  enabled: true
+  persistence:
+    # postgresql.persistence.size -- Size of the PostgreSQL pvc
+    size: 1Gi
+  # postgresql.fullnameOverride -- Name override for the PostgreSQL deployment
+  fullnameOverride: postgresql
+  # postgresql.pgPass -- Password for the master PostgreSQL user.
+  # Feeds into the `ordinopostgrescredentials` secret that is provided to the PostgreSQL chart
+  pgPass: pass
+  # postgresql.existingSecret -- Name of existing secret that holds passwords for PostgreSQL
+  existingSecret: ordinopostgrescredentials
+
+mongodb:
+  # mongodb.enabled -- Flag to control whether to deploy MongoDB
+  enabled: true
+  # mongodb.fullnameOverride -- Name override for the MongoDB deployment
+  fullnameOverride: mongodb
+  persistence:
+    enabled: true
+    # mongodb.persistence.size -- Size of the MongoDB pvc
+    size: 1Gi
+  auth:
+    # mongodb.auth.enabled -- Flag to control whether to enable authentication
+    enabled: false
+    # mongodb.auth.username -- MongoDB custom user (mandatory if auth.database is set)
+    username: *MongoDBUser
+    # mongodb.auth.password -- MongoDB custom user password
+    password: *MongoDBPass
+    # mongodb.auth.database -- MongoDB custom database
+    database: *MongoDBName

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: nginx
-  pullPolicy: IfNotPresent
+  repository: caleydo
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
@@ -20,6 +20,15 @@ MongoDBUser: &MongoDBUser "ordinoAdmin"
 MongoDBPass: &MongoDBPass "ordinoAdmin"
 
 ordino:
+  server:
+    image: caleydo/ordino_server
+    tag: starter
+    port: 9000
+    debug: true
+  web:
+    image: caleydo/ordino
+    tag: starter
+    port: 80
   redis:
     # ordino.redis.host -- Name of the Redis host to be used
     host: "redis-headless"
@@ -34,6 +43,8 @@ ordino:
     host: "mongodb"
     # ordino.mongodb.port -- MongoDB port
     port: "27017"
+    # ordino.mongodb.extraArgs -- Extra arguments for the mongo connection string. Must always start with '?' e.g. '?ssl=true&ssl_ca_certs=/mongodb-certs/cert.pem'
+    extraArgs: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -111,7 +122,7 @@ redis:
   master:
     persistence:
       # redis.master.persistence.enabled -- Enable redis volume claim
-      enabled: false
+      enabled: true
       # redis.master.persistence.size -- Size of the volume claim
       size: 1Gi
   # redis.usePassword -- Use password for accessing redis
@@ -142,10 +153,22 @@ mongodb:
     size: 1Gi
   auth:
     # mongodb.auth.enabled -- Flag to control whether to enable authentication
-    enabled: false
+    enabled: true
     # mongodb.auth.username -- MongoDB custom user (mandatory if auth.database is set)
     username: *MongoDBUser
     # mongodb.auth.password -- MongoDB custom user password
     password: *MongoDBPass
     # mongodb.auth.database -- MongoDB custom database
     database: *MongoDBName
+    # mongodb.auth.rootPassword -- MongoDB admin password
+    rootPassword: *MongoDBPass
+  # mongodb.initdbScripts -- List of scripts to run on first deployment of the Mongo dependency
+  initdbScripts:
+    my_init_script.sh: |
+      #!/bin/bash
+      echo "Creating mongo user..."
+      mongo  -u root -p ordinoAdmin --authenticationDatabase admin targid --eval "db.createUser({user: 'ordinoAdmin', pwd: 'ordinoAdmin', roles: [{role: 'dbOwner', db: 'targid'}]});"
+      mongo  -u root -p ordinoAdmin --authenticationDatabase admin graph --eval "db.createUser({user: 'ordinoAdmin', pwd: 'ordinoAdmin', roles: [{role: 'dbOwner', db: 'graph'}]});"
+      echo "Mongo user created."
+
+      


### PR DESCRIPTION
adds MongoDB, Redis and PostgreSQL into list of dependencies and removes them from the multicontainer deployment
splits ordino containers into separate deployments
adds ordino values and sets them up in the server configuration