### PR TITLE
Test Ordino Tours with Cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,9 @@ jobs:
             - ~/.cache
       - run: $(npm bin)/cypress run
       - store_artifacts:
-          path: /root/app/cypress/
+          path: /root/app/cypress/screenshots
+      - store_artifacts:
+          path: /root/app/cypress/videos
 workflows:
   version: 2
   build-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,8 @@ jobs:
             - ~/.npm
             - ~/.cache
       - run: $(npm bin)/cypress run
+      - store_artifacts:
+          path: /root/app/cypress/
 workflows:
   version: 2
   build-nightly:
@@ -139,10 +141,11 @@ workflows:
       - test
   build-branch:
     jobs:
-      - build:
-          filters:
-            tags:
-              ignore: /^v.*/
+      - test
+      # - build:
+      #     filters:
+      #       tags:
+      #         ignore: /^v.*/
   build-tag:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             - v1-deps
       - run:
           name: Install Dependencies
-          command: npm ci
+          command: npm install
       - save_cache:
           key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
           # cache NPM modules and the folder with the Cypress binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,4 @@
-version: 2.1
-orbs:
-  # "cypress-io/cypress@1" installs the latest published
-  # version "1.x.y" of the orb. We recommend you then use
-  # the strict explicit version "cypress-io/cypress@1.x.y"
-  # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@1
+version: 2
 jobs:
   build:
     working_directory: ~/phovea
@@ -98,7 +92,29 @@ jobs:
               aws --output text ecs run-task --cluster caleydo --task-definition ${awsFamily} --started-by CircleCIAutoUpdate
             fi
   test:
-
+    docker:
+      - image: cypress/base:10
+        environment:
+          ## this enables colors in the output
+          TERM: xterm
+    working_directory: ~/app
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+          # cache NPM modules and the folder with the Cypress binary
+          paths:
+            - ~/.npm
+            - ~/.cache
+      - run: $(npm bin)/cypress run
 workflows:
   version: 2
   build-nightly:
@@ -120,7 +136,7 @@ workflows:
     #           only:
     #             - develop
     jobs:
-      - cypress/run
+      - test
   build-branch:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
               fi
               aws --output text ecs run-task --cluster caleydo --task-definition ${awsFamily} --started-by CircleCIAutoUpdate
             fi
-  test:
+  cypress:
     docker:
       - image: cypress/base:10
         environment:
@@ -131,23 +131,22 @@ workflows:
                 - develop
     jobs:
       - build
-  test-nightly:
-    # triggers:
-    #   - schedule: # nightly test during weekday (2 hours after build)
-    #       cron: "15 3 * * 1-5"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - develop
+  cypress-nightly:
+    triggers:
+      - schedule: # nightly test during weekday (2 hours after build)
+          cron: "15 3 * * 1-5"
+          filters:
+            branches:
+              only:
+                - develop
     jobs:
-      - test
+      - cypress
   build-branch:
     jobs:
-      - test
-      # - build:
-      #     filters:
-      #       tags:
-      #         ignore: /^v.*/
+      - build:
+          filters:
+            tags:
+              ignore: /^v.*/
   build-tag:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
-version: 2
+version: 2.1
+orbs:
+  # "cypress-io/cypress@1" installs the latest published
+  # version "1.x.y" of the orb. We recommend you then use
+  # the strict explicit version "cypress-io/cypress@1.x.y"
+  # to lock the version and prevent unexpected CI changes
+  cypress: cypress-io/cypress@1
 jobs:
   build:
     working_directory: ~/phovea
@@ -91,6 +97,7 @@ jobs:
               fi
               aws --output text ecs run-task --cluster caleydo --task-definition ${awsFamily} --started-by CircleCIAutoUpdate
             fi
+  test:
 
 workflows:
   version: 2
@@ -104,6 +111,16 @@ workflows:
                 - develop
     jobs:
       - build
+  test-nightly:
+    # triggers:
+    #   - schedule: # nightly test during weekday (2 hours after build)
+    #       cron: "15 3 * * 1-5"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - develop
+    jobs:
+      - cypress/run
   build-branch:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
               fi
               aws --output text ecs run-task --cluster caleydo --task-definition ${awsFamily} --started-by CircleCIAutoUpdate
             fi
-  cypress:
+  cypress: # the job is taken from https://docs.cypress.io/guides/guides/continuous-integration.html#Example-circleci-config-yml-v2-config-file
     docker:
       - image: cypress/base:10
         environment:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ package-lock.json
 !Jenkinsfile
 !docker_script.sh
 !docker-compose-patch.*
+
+# Cypress
+!cypress.json
+!cypress/
+!cypress/**
+cypress/screenshots/*
+cypress/videos/*

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,9 +1,0 @@
-{
-  "generator-phovea": {
-    "type": "product",
-    "name": "ordino_product",
-    "author": "Samuel Gratzl",
-    "today": "Wed, 11 Jan 2017 10:31:55 GMT",
-    "githubAccount": "Caleydo"
-  }
-}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Testing
 npm test
 ```
 
+## Run Cypress tests
+
+On Windows 10 + WLS 2 [install and run the VcXsrv](https://dev.to/nickymeuleman/using-graphical-user-interfaces-like-cypress-in-wsl2-249j) before proceeding.
+
+1. `npm install`
+2. `npm run cy:run` for headless mode or `npm run cy:open` to open the dashboard and select test manually
+
+
 Building
 --------
 
@@ -38,4 +46,3 @@ This repository is part of **[Phovea](http://phovea.caleydo.org/)**, a platform 
 [phovea-url]: https://phovea.caleydo.org
 [circleci-image]: https://circleci.com/gh/Caleydo/ordino_product.svg?style=shield
 [circleci-url]: https://circleci.com/gh/Caleydo/ordino_product
-

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,4 @@
+{
+  "viewportWidth": 1920,
+  "viewportHeight": 1080
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,7 @@
 {
   "viewportWidth": 1920,
-  "viewportHeight": 1080
+  "viewportHeight": 1080,
+  "env": {
+    "host": "https://ordino-daily.caleydoapp.org"
+  }
 }

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -34,7 +34,7 @@ function getTourIds() {
 context('Ordino Tours', () => {
 
   it('Test all tours', () => {
-    cy.visit('https://ordino-daily.caleydoapp.org', {
+    cy.visit(Cypress.env('host'), {
       onBeforeLoad: (win) => {
         // workaround to clear sessionStorage (see https://github.com/cypress-io/cypress/issues/413#issuecomment-356969904)
         win.sessionStorage.clear();

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -44,7 +44,7 @@ context('Ordino Tours', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
-    cy.get('#cookie-bar-button').should('be.visible').click();
+    // cy.get('#cookie-bar-button', { timeout: 10000 }).should('be.visible').click();
 
     cy.get('#loginDialog button').should('be.visible').contains('Login').click();
 

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -1,0 +1,80 @@
+/// <reference types="cypress" />
+
+function checkTour() {
+  cy.get('.tdp-tour-step-dots > div')
+    .each(($el, index, $list) => {
+      // check that the step counter shows the correct number
+      cy.get('.tdp-tour-step-count').should(($node) => {
+        expect($node).to.contain(index + 1);
+      });
+
+      if($list.length === index+1) {
+        cy.get('.tdp-tour-step-navigation button').contains('Finish').click();
+      } else {
+        cy.get('.tdp-tour-step-navigation button').contains('Next').click();
+      }
+    });
+}
+
+function getTourIds() {
+  let ids = [];
+  // open the tour chooser dialog
+  cy.get('a[data-target="#tdpTourChooser"]').should('be.visible').click();
+
+  return new Cypress.Promise((resolve) => {
+    cy.get('#tdpTourChooser .modal-body ul > li')
+      .should('be.visible') // make sure the dialog is visible
+      .each($el =>
+        cy.wrap($el).invoke('attr', 'data-id').then(id => ids.push(id))
+      )
+      .then(() => resolve(ids));
+  });
+}
+
+context('Ordino Tours', () => {
+
+  it('Test all tours', () => {
+    cy.visit('https://ordino-daily.caleydoapp.org', {
+      onBeforeLoad: (win) => {
+        // workaround to clear sessionStorage (see https://github.com/cypress-io/cypress/issues/413#issuecomment-356969904)
+        win.sessionStorage.clear();
+      }
+    });
+
+    cy.clearCookies();
+    cy.clearLocalStorage();
+
+    cy.get('#cookie-bar-button').should('be.visible').click();
+
+    cy.get('#loginDialog button').should('be.visible').contains('Login').click();
+
+    cy.wait(500);
+
+    // dismiss database migration dialog
+    cy.get('.modal-title').should('be.visible').contains('Ordino just got better!').closest('.modal-content').find('.modal-footer button').contains('Close').click();
+
+    getTourIds().then((ids) => {
+      // loop through every tour
+      ids.forEach((id) => {
+        // find and start current tour
+        cy.get(`#tdpTourChooser .modal-body ul > li[data-id="${id}"]`).find('a').click();
+
+        checkTour();
+
+        // open tour chooser dialog again
+        cy.get('a[data-target="#tdpTourChooser"]').should('be.visible').click();
+      });
+
+      // final check if all tours are tested
+      cy.get('#tdpTourChooser .modal-body ul > li').should(($lis) => {
+        expect($lis).to.have.length(ids.length);
+
+        const allChecked = $lis.get().every((li) => {
+          return li.querySelector('i').classList.contains('fa-check-square');
+        });
+
+        expect(allChecked).to.eq(true);
+      });
+    });
+  });
+});

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -44,7 +44,7 @@ context('Ordino Tours', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
-    cy.get('#cookie-bar-button').then(($button) => {
+    cy.get('body').find('#cookie-bar-button').then(($button) => {
       if($button) {
         cy.get('#cookie-bar-button').click();
       }

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -44,7 +44,11 @@ context('Ordino Tours', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
-    // cy.get('#cookie-bar-button', { timeout: 10000 }).should('be.visible').click();
+    cy.get('#cookie-bar-button').then(($button) => {
+      if($button) {
+        cy.get('#cookie-bar-button').click();
+      }
+    });
 
     cy.get('#loginDialog button').should('be.visible').contains('Login').click();
 

--- a/cypress/integration/tdp_publicdb/ordino-tours.spec.js
+++ b/cypress/integration/tdp_publicdb/ordino-tours.spec.js
@@ -44,15 +44,20 @@ context('Ordino Tours', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
-    cy.get('body').find('#cookie-bar-button').then(($button) => {
-      if($button) {
-        cy.get('#cookie-bar-button').click();
+    cy.wait(500); // wait for cookie bar to load and initialize
+
+    cy.get('#cookie-bar-button').should(($button) => {
+      if ($button.length === 0) {
+        console.log('no #cookie-bar-button found');
+        return; // no cookie bar visible (e.g., if called with an IP outside of the EU)
       }
+      console.log('click #cookie-bar-button');
+      $button[0].click(); // if cookie bar is visible click the button to hide the bar
     });
 
     cy.get('#loginDialog button').should('be.visible').contains('Login').click();
 
-    cy.wait(500);
+    cy.wait(500); // wait to finish login and start provenance graph
 
     // dismiss database migration dialog
     cy.get('.modal-title').should('be.visible').contains('Ordino just got better!').closest('.modal-content').find('.modal-footer button').contains('Close').click();

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "scripts": {
     "build": "node build.js --skipTests",
     "predist": "npm run build",
-    "dist": "mkdir dist && cd build && tar cvzf ../dist/ordino_product.tar.gz *"
+    "dist": "mkdir dist && cd build && tar cvzf ../dist/ordino_product.tar.gz *",
+    "cy:open": "cypress open",
+    "cy:run": "cypress run"
   },
   "dependencies": {
     "bluebird": "3.7.2",
@@ -30,5 +32,8 @@
     "yamljs": "0.3.0",
     "yargs-parser": "18.0.0",
     "yeoman-environment": "2.8.0"
+  },
+  "devDependencies": {
+    "cypress": "^4.12.1"
   }
 }


### PR DESCRIPTION
This PR adds Cypress as npm dependency and tests that click through all deployed Ordino tours.

* Currently, https://ordino-daily.caleydoapp.org is tested; the host can be configured in the _cypress.json_ (see https://docs.cypress.io/guides/guides/environment-variables.html for further information)
* The Cypress test runs every night 2 hours after the nightly build job (see CircleCI _config.yml_)
* Screenshots and video are stored as artifacts for each CircleCI run

