### PR TITLE
Rewrite path of phoveaMetaData.json and buildInfo.json in nginx

### DIFF
--- a/templates/web/deploy/web/nginx-default.conf
+++ b/templates/web/deploy/web/nginx-default.conf
@@ -73,6 +73,16 @@ server {
 
         proxy_intercept_errors on;
     }
+    
+    location /app/phoveaMetaData.json {
+        # get file from root and not the app directory
+        rewrite ^/app(/.*)$ $1 last;
+    }
+    
+    location /app/buildInfo.json {
+        # get file from root and not the app directory
+        rewrite ^/app(/.*)$ $1 last; 
+    }
 }
 
 gzip on;


### PR DESCRIPTION
Closes https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1240

Required PR https://github.com/phovea/phovea_ui/pull/152

### Summary

* Instead of changing the request in phovea_ui we rewrite the path in nginx
* `/app/phoveaMetaData.json` is rewritten to (and requested from) `/phoveaMetaData.json`
* `/app/buildInfo.json` is rewritten to (and requested from) `/buildInfo.json`


Locally, we do not have a NGINX, but a webpack dev server (including proxy). Therefore, you need to add the following to your `devServerProxy` key in `.yo-rc-workspace.json`: 

```json
  "devServerProxy": {
    "/app/buildInfo.json": {
      "target": "http://localhost:8080",
      "pathRewrite": { "^/app": "" },
      "secure": false
    },
    "/app/phoveaMetaData.json": {
      "target": "http://localhost:8080",
      "pathRewrite": { "^/app": "" },
      "secure": false
    }
  },
```

The change is also documented in the wiki: https://wiki.datavisyn.io/internal/projects/ordino/ordino-public