### PR TITLE
Add nginx path alias

### DIFF
--- a/templates/web/deploy/web/nginx-default.conf
+++ b/templates/web/deploy/web/nginx-default.conf
@@ -84,7 +84,7 @@ server {
         rewrite ^/app(/.*)$ $1 last; 
     }
 
-    location /app/tourdino/* {
+    location /app/tourdino/ {
         # get file from root and not the app directory
         rewrite ^/app(/.*)$ $1 last; 
     }

--- a/templates/web/deploy/web/nginx-default.conf
+++ b/templates/web/deploy/web/nginx-default.conf
@@ -83,6 +83,11 @@ server {
         # get file from root and not the app directory
         rewrite ^/app(/.*)$ $1 last; 
     }
+
+    location /app/tourdino/* {
+        # get file from root and not the app directory
+        rewrite ^/app(/.*)$ $1 last; 
+    }
 }
 
 gzip on;


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#1317
### Summary 
Changes for the dev server:
Extend `devServerProxy` object in your `.yo-rc-workspace.json `
```json
"devServerProxy": {
    "/app/tourdino/*": {
      "target": "http://localhost:8080",
      "pathRewrite": {
        "^/app": ""
      },
      "secure": false
    }
  },
```
I am not sure if the syntax with the wildcard is correct
see https://github.com/Caleydo/tourdino/pull/86